### PR TITLE
Fix and enable early stopping in tei mode

### DIFF
--- a/analysis/src/analysis.rs
+++ b/analysis/src/analysis.rs
@@ -334,7 +334,7 @@ pub fn analyze<const N: usize>(config: AnalysisConfig<N>, state: &State<N>) -> A
             break;
         }
 
-        if let Some(time_limit) = config.time_limit {
+        if let Some(time_limit) = time_limit {
             let prediction = analysis.time + Duration::from_secs_f64(next_iteration_prediction);
 
             // Stop if the next iteration is predicted to exceed the time limit and we've

--- a/client/src/args.rs
+++ b/client/src/args.rs
@@ -430,7 +430,7 @@ impl FromArgMatches for TeiConfig {
             Ai {
                 depth_limit: None,
                 time_limit: None,
-                early_stop: false,
+                early_stop: true,
                 exact_eval: false,
                 threads: 1,
             },


### PR DESCRIPTION
Enable early stopping by default in tei mode, to avoid wasting time on search iterations that are interrupted before they can finish. The extra fix in `analysis.rs` was just a programming error, as far as I can tell.

Result from a 6x6 10+0.1 match (no hyperthreading):
```
Played 2000 games.
takkerus_early_stop vs takkerus: +1102-865=33, +41 elo [+25, +56] (95% confidence). 1016 white wins, 951 black wins.
```